### PR TITLE
Remove . from friendlyname for identifying LG TVs

### DIFF
--- a/src/Jellyfin.Plugin.Dlna/Profiles/Xml/LG Smart TV.xml
+++ b/src/Jellyfin.Plugin.Dlna/Profiles/Xml/LG Smart TV.xml
@@ -3,7 +3,7 @@
   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <Name>LG Smart TV</Name>
   <Identification>
-    <FriendlyName>LG.*</FriendlyName>
+    <FriendlyName>LG*</FriendlyName>
     <Headers>
       <HttpHeaderInfo name="User-Agent" value="LG" match="Substring" />
     </Headers>


### PR DESCRIPTION
Some LG models do not have a . in their broadcasted name